### PR TITLE
Enable saving more params when logging through /pxl

### DIFF
--- a/winterwell.datalog/src/java/com/winterwell/datalog/server/LgServlet.java
+++ b/winterwell.datalog/src/java/com/winterwell/datalog/server/LgServlet.java
@@ -81,7 +81,7 @@ public class LgServlet {
 	static final BoolField track = new BoolField("track");
 	
 	/**
-	 * Log msg to fast.log file.  
+	 * Log msg to fast.log file and send appropriate response
 	 * @param req
 	 * @param resp
 	 * @throws IOException 
@@ -125,7 +125,7 @@ public class LgServlet {
 //		if (ref != null) {
 //			readGoogleAnalyticsTokens(ref, params);
 //		}
-						
+
 		// group by
 		String gby = state.get(GBY);
 		if (gby==null) {
@@ -150,6 +150,9 @@ public class LgServlet {
 			}
 		}
 		
+		// Has the request already received a response (eg from TrackingPixelServlet)? Stop here.
+		if (!state.isOpen()) return;
+
 		// Reply		
 		// Send a .gif for a pixel?
 		if (state.getResponseType()==KResponseType.image) {


### PR DESCRIPTION
Preflight testing for Green Pixel stuff showed that params like "campaign" weren't getting through to the logged data from the /pxl endpoint, which was going to make it tricky to differentiate data. So...

TrackingPixelServlet.process() changed to invoke LgServlet.fastLog() instead of doLog.
- No longer extracts dataspace and tag params - instead, adds its own defaults (d=trk, evt=pxl) to the request for LgServlet.fastLog() to find, if they're absent.
- No longer extracts gby param - fastLog does this already.

LgServlet.fastLog() changed to not attempt to send a response to an already-closed request.
- Done because TrackingPixelServlet.process() alreadysends the pixel image response ASAP so the requesting party isn't waiting for us to finish processing logging data.