### PR TITLE
stop null name throwing deserialisation

### DIFF
--- a/winterwell.web/src/com/winterwell/web/data/XId.java
+++ b/winterwell.web/src/com/winterwell/web/data/XId.java
@@ -104,12 +104,8 @@ public final class XId implements Serializable, IHasJson, CharSequence, Comparab
 	 * {@link #XId(String, String)}.
 	 */
 	public XId(String name, String service, boolean checkName) {
-		this.service = service;
-		this.name = name;
-		assert notNullNameCheck() : name+"@"+service;
-		assert ! checkName : "Wrong constructor! This one is for checkName=false "+this;
+		this(name+"@"+service, checkName);
 		assert ! service.contains("@") : "Bad service: "+service+" for "+this;
-		return;
 	}
 
 	/**
@@ -166,7 +162,7 @@ public final class XId implements Serializable, IHasJson, CharSequence, Comparab
 	 * the name.
 	 */
 	public XId(String id, boolean canonicaliseName) {
-		assert ! canonicaliseName;
+		assert ! canonicaliseName : "Wrong constructor! This one is for checkName=false "+this;
 		int i = id.lastIndexOf('@');
 		// handle unescaped web inputs -- with some log noise 'cos we don't want this
 		if (i==-1 && id.contains("%40")) {
@@ -178,11 +174,13 @@ public final class XId implements Serializable, IHasJson, CharSequence, Comparab
 			Log.e("xid.format", new Warning("No @ in XId: "+id));
 			this.service="unknown";
 			this.name=id;
-			return;
+		} else {
+			this.service = id.substring(i+1);
+			this.name = id.substring(0, i);
 		}
-		this.service = id.substring(i+1);
-		this.name = id.substring(0, i);
-		assert notNullNameCheck() : "null name in XId: "+id;
+		if ( ! notNullNameCheck()) {
+			Log.e(service, "(ignoring) null name in XId: "+id);
+		}
 	}
 
 	/**


### PR DESCRIPTION
To fix the error seen here: https://calstat.good-loop.com/task/_stats?q=closed%3Afalse%20AND%20due%3Abefore%3Aend-of-week


500: null name in XId: @unknown 

<details>AssertionError: WebRequest:user=AuthToken[daniel@good-loop.com@email]:action=null:req={ya_auths=XXX, q=closed:false AND due:before:end-of-week, CORS_set=true}-Browser[linux chrome mobile=false] (wraps) null name in XId: @unknown null name in XId: @unknown
	java.lang.AssertionError: null name in XId: @unknown
	at com.winterwell.web.data.XId.<init>(XId.java:185)
	at com.winterwell.es.XIdTypeAdapter.deserialize(XIdTypeAdapter.java:26)
	at com.winterwell.es.XIdTypeAdapter.deserialize(XIdTypeAdapter.java:20)
	at com.winterwell.gson.TreeTypeAdapter.read(TreeTypeAdapter.java:59)
	at com.winterwell.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:42)
	at com.winterwell.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:112)
	at com.winterwell.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:68)
	at com.winterwell.gson.internal.bind.ReflectiveTypeAdapterBoundField.read(ReflectiveTypeAdapterBoundField.java:67)
	at com.winterwell.gson.internal.bind.ReflectiveTypeAdapter.read(ReflectiveTypeAdapter.java:106)
	at com.winterwell.gson.internal.bind.ReflectiveTypeAdapter.read(ReflectiveTypeAdapter.java:74)
	at com.winterwell.gson.Gson.fromJson(Gson.java:1151)
	at com.winterwell.gson.internal.bind.ReflectiveTypeAdapter.read3_value(ReflectiveTypeAdapter.java:202)
	at com.winterwell.gson.internal.bind.ReflectiveTypeAdapter.read2_map(ReflectiveTypeAdapter.java:171)
	at com.winterwell.gson.internal.bind.ReflectiveTypeAdapter.read2_justAMap(ReflectiveTypeAdapter.java:127)
	at com.winterwell.gson.internal.bind.ReflectiveTypeAdapter.read(ReflectiveTypeAdapter.java:84)
	at com.winterwell.gson.internal.bind.ReflectiveTypeAdapter.read3_value(ReflectiveTypeAdapter.java:195)
	at com.winterwell.gson.internal.bind.ReflectiveTypeAdapter.read2_map(ReflectiveTypeAdapter.java:171)
	at com.winterwell.gson.internal.bind.ReflectiveTypeAdapter.read2_justAMap(ReflectiveTypeAdapter.java:127)
	at com.winterwell.gson.internal.bind.ReflectiveTypeAdapter.read(ReflectiveTypeAdapter.java:84)
	at com.winterwell.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:42)
	at com.winterwell.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:220)
	at com.winterwell.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:171)
	at com.winterwell.gson.Gson.fromJson(Gson.java:1151)
	at com.winterwell.gson.Gson.fromJson(Gson.java:1077)
	at com.winterwell.gson.Gson.fromJson(Gson.java:999)
	at com.winterwell.gson.Gson.fromJson(Gson.java:958)
	at com.winterwell.es.client.ESHttpResponse.getParsedJson(ESHttpResponse.java:135)
	at com.winterwell.es.client.ESHttpResponse.getAggregations(ESHttpResponse.java:323)
	at com.goodloop.tasks.TaskServlet.doStats(TaskServlet.java:191)
	at com.winterwell.web.app.CrudServlet.process(CrudServlet.java:155)