### PR TITLE
cronjob tweak

### DIFF
--- a/goodloop.google/generate.chat.schedule.sh
+++ b/goodloop.google/generate.chat.schedule.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-java -cp build-lib/goodloop.google.jar:build-lib/* com.goodloop.gcal.chatroundabout.ChatRoundaboutMain
+cd /home/winterwell/open-code/goodloop.google && java -cp build-lib/goodloop.google.jar:build-lib/* com.goodloop.gcal.chatroundabout.ChatRoundaboutMain


### PR DESCRIPTION
Hello,

This is the error being thrown when the cronjob runs:

```
Error: Could not find or load main class com.goodloop.gcal.chatroundabout.ChatRoundaboutMain
Caused by: java.lang.ClassNotFoundException: com.goodloop.gcal.chatroundabout.ChatRoundaboutMain
```

This suggests that during the build-and-run script, we're not in the right directory when starting the JVM. 

Added a tweak to cd to that directory before running the JAR. 