### PR TITLE
Feature/2022 04/log user xid

### DIFF
--- a/winterwell.datalog/src/java/com/winterwell/datalog/server/LgServlet.java
+++ b/winterwell.datalog/src/java/com/winterwell/datalog/server/LgServlet.java
@@ -24,6 +24,7 @@ import com.winterwell.datalog.DataLogRemoteStorage;
 import com.winterwell.datalog.Dataspace;
 import com.winterwell.json.JSONObject;
 import com.winterwell.utils.Dep;
+import com.winterwell.utils.IProperties;
 import com.winterwell.utils.MathUtils;
 import com.winterwell.utils.Printer;
 import com.winterwell.utils.StrUtils;
@@ -49,6 +50,8 @@ import com.winterwell.web.fields.BoolField;
 import com.winterwell.web.fields.DoubleField;
 import com.winterwell.web.fields.JsonField;
 import com.winterwell.web.fields.SField;
+import com.winterwell.youagain.client.AuthToken;
+import com.winterwell.youagain.client.YouAgainClient;
 
 import ua_parser.Client;
 import ua_parser.Parser;
@@ -381,7 +384,7 @@ public class LgServlet {
 			return params; // dont add tracking params for our own server calls
 		}
 		params.putIfAbsent("ua", ua);
-		// Replace $user with tracking-id, and $
+		// Replace $user with tracking-id, and $		
 		params.putIfAbsent("user", trckId);			
 		// ip: $ip
 		params.putIfAbsent("ip", state.getRemoteAddr());

--- a/winterwell.datalog/src/java/com/winterwell/datalog/server/TrackingPixelServlet.java
+++ b/winterwell.datalog/src/java/com/winterwell/datalog/server/TrackingPixelServlet.java
@@ -75,7 +75,7 @@ public class TrackingPixelServlet implements IServlet {
 		if (yac != null) {
 			List<AuthToken> authTokens = yac.getAuthTokens(state);
 			if ( ! authTokens.isEmpty()) {
-				// TODO prefer verified and recent tokens				
+				// TODO prefer verified and recent tokens. Also prefer email.			
 				uid = authTokens.get(0).xid.toString();
 				return uid;
 			}			


### PR DESCRIPTION
This uses cookie login tokens to set the user tracking in events.

**Possible Issues**

 - I think T4G sets `user` explicitly when logging `tabopen`. Not sure which setting wins. Hopefully harmless as the values should be the same. 